### PR TITLE
Update documentation according to recent Fink release (0.2.1)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -53,6 +53,12 @@ export HBASE_HOME=/usr/local/hbase
 export PATH=$PATH:$HBASE_HOME/bin
 ```
 
+and start the service:
+
+```bash
+$HBASE_HOME/bin/start-hbase.sh
+```
+
 Clone the repository:
 
 ```bash

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,3 +1,32 @@
+# 0.2.0 -> 0.2.1
+
+### General
+
+- Transfer documentation outside of the repo (#223 )
+- New service: Fink shell (#227 )
+
+### Raw database to science database
+
+- Add capability to manipulate the data (level one) from generic modules (#209)
+- Make optional the use of cross-match in raw2science (#222 )
+- Add the path to the HBase configuration file when running raw2science (#195 )
+
+### Alert redistribution
+
+- Add timestamp-based streaming to Alert distribution service (#201 )
+- Filtering alerts before distribution (#206 )
+- Add level two generic filter (#216 )
+
+### Other minor fixes
+
+- several typo and bug fixes:
+  - fix typo in checkstream (#202 )
+  - Update gitignore with mgmt files (#211 )
+  - Catch TimeoutError and ConnectionError when doing xmatch with CDS (#221 )
+  - PEP8 rules (#214 )
+
+Thanks @cAbhi15 for many contributions!
+
 # 0.2.0
 
 - Print version number from the binary (#132)

--- a/docs/user_guide/configuration.md
+++ b/docs/user_guide/configuration.md
@@ -72,7 +72,7 @@ org.apache.spark:spark-avro_2.11:2.4.1
 In addition to packages, you can specify external libraries as jars:
 ```
 # These two are shipped with the code - use the latest version
-FINK_JARS=${FINK_HOME}/libs/fink-broker_2.11-0.2.0.jar,\
+FINK_JARS=${FINK_HOME}/libs/fink-broker_2.11-0.2.1.jar,\
 ${FINK_HOME}/libs/shc-core-1.1.3-2.4-s_2.11.jar
 ```
 

--- a/docs/user_guide/testing-fink.md
+++ b/docs/user_guide/testing-fink.md
@@ -137,3 +137,23 @@ source $FINK_HOME/conf/fink.conf.travis
 ```
 
 A custom configuration file can be given as an argument `fink_test -c /path/to/custom.conf`
+
+## Debugging using the Fink shell
+
+We have a service to launch a pyspark shell (ipython or jupyter) with Fink configuration pre-loaded:
+
+```
+Launch pyspark shell with Fink configuration pre-loaded
+
+ Usage:
+ 	fink_shell [option]
+
+ Option:
+ 	-c <CONFIGURATION_FILE>
+ 		Specify a configuration file. Default is conf/fink.conf.shell
+
+ 	-h, --help
+ 		To view this help message
+```
+
+You can configure it using the `conf/fink.conf.shell` configuration file provided.


### PR DESCRIPTION
This PR adds documentation to reflect the version 0.2.1 of Fink. It also describes the usage of the Fink shell.