### PR TITLE
Update the added values section with the new microlensing outputs

### DIFF
--- a/docs/science/added_values.md
+++ b/docs/science/added_values.md
@@ -6,5 +6,9 @@ In addition to the information contained in the incoming raw alerts (see [ZTF al
 |:--------|:-------|:--------|
 | `cdsxmatch` | string | Counterpart (cross-match) in the Simbad database |
 | `rfscore` | float | Probability to be a SN Ia based on Random Forest classifier (1 is SN Ia). Based on https://arxiv.org/abs/1804.03765 |
+| `mulens.class_1` | string | predicted class by [LIA](https://github.com/dgodinez77/LIA) for filter band g |
+| `mulens.ml_score_1` | float | probability of an alert by [LIA](https://github.com/dgodinez77/LIA) (0 to 1) to be a microlensing event in filter band g using a Random Forest Classifier |
+| `mulens.class_2` | string | predicted class by [LIA](https://github.com/dgodinez77/LIA) for filter band r |
+| `mulens.ml_score_2` | float | probability of an alert by [LIA](https://github.com/dgodinez77/LIA) (0 to 1) to be a microlensing event in filter band r using a Random Forest Classifier |
 
 Over time, there will be more added values available - and feel free to propose new modules!


### PR DESCRIPTION
The microlensing module (mulens) add 4 new fields. They are the predicted classes (among microlensing ML, variable star VAR, cataclysmic event CV, and constant event CONST) & probability of an alert (0 to 1) to be a microlensing event in each ZTF band (g & r) using a Random Forest Classifier.